### PR TITLE
dagrr: add support for GPU deployments

### DIFF
--- a/dagrr/fly.go
+++ b/dagrr/fly.go
@@ -15,21 +15,15 @@ type DagrrFly struct {
 
 // App manifest: `dagger call on-flyio --token=env:FLY_API_TOKEN manifest file --path=fly.toml export --path=fly.toml`
 func (m *DagrrFly) Manifest(
-	// Disk size in GB
-	//
+	// Primary region to use for deploying new machines, see https://fly.io/docs/reference/configuration/#primary-region
 	// +optional
-	// +default="100GB"
-	disk string,
+	primaryRegion string,
 
 	// VM size, see https://fly.io/docs/about/pricing/#compute
 	//
 	// +optional
 	// +default="performance-2x"
 	size string,
-
-	// Primary region to use for deploying new machines, see https://fly.io/docs/reference/configuration/#primary-region
-	// +optional
-	primaryRegion string,
 
 	// Memory to request, see https://fly.io/docs/reference/configuration/#memory
 	// +optional
@@ -38,6 +32,12 @@ func (m *DagrrFly) Manifest(
 	// GPU kind to use, see https://fly.io/docs/reference/configuration/#gpu_kind
 	// +optional
 	gpuKind string,
+
+	// Disk size in GB
+	//
+	// +optional
+	// +default="100GB"
+	disk string,
 
 	// Environment variables to export on the machine, see https://fly.io/docs/reference/configuration/#the-env-variables-section
 	// Each env var needs to follow the TOML format (eg. MY_KEY = "value")

--- a/dagrr/fly.go
+++ b/dagrr/fly.go
@@ -123,13 +123,12 @@ kill_timeout = 30
 // Then: `export _EXPERIMENTAL_DAGGER_RUNNER_HOST=tcp://<APP_NAME>.internal:2345`
 // Assumes https://fly.io/docs/networking/private-networking (clashes with Tailscale MagicDNS)
 func (m *DagrrFly) Deploy(
+	ctx context.Context,
 	// +optional
 	dir *dagger.Directory,
 	// +optional
 	regions []string,
 ) (string, error) {
-	ctx := context.Background()
-
 	create, err := m.Flyio.Create(ctx, m.Dagrr.App)
 	if err != nil {
 		return create, err
@@ -142,4 +141,9 @@ func (m *DagrrFly) Deploy(
 	return m.Flyio.Deploy(ctx, dir, dagger.FlyioDeployOpts{
 		Regions: regions,
 	})
+}
+
+// Destroy the application: `dagger call on-flyio --token=env:FLY_API_TOKEN destroy`
+func (m *DagrrFly) Destroy(ctx context.Context) {
+	m.Flyio.Destroy(ctx, m.Dagrr.App)
 }

--- a/dagrr/fly.go
+++ b/dagrr/fly.go
@@ -58,6 +58,11 @@ func (m *DagrrFly) Manifest(
 		envVars = fmt.Sprintf("%s  %s\n", envVars, envVar)
 	}
 
+	engineImageFlavor := ""
+	if gpuKind != "" {
+		engineImageFlavor = "-gpu"
+	}
+
 	toml := fmt.Sprintf(`# https://fly.io/docs/reference/configuration/
 
 app = "%s"
@@ -69,7 +74,7 @@ kill_timeout = 30
 %s
 
 [build]
-  image = "registry.dagger.io/engine:v%s"
+  image = "registry.dagger.io/engine:v%s%s"
 
 [mounts]
   source = "dagger"
@@ -101,7 +106,7 @@ kill_timeout = 30
 
 [[vm]]
   size = "%s"
-`, m.Dagrr.App, primaryRegion, envVars, m.Dagrr.Version, disk, size)
+`, m.Dagrr.App, primaryRegion, envVars, m.Dagrr.Version, engineImageFlavor, disk, size)
 
 	if memory != "" {
 		toml = fmt.Sprintf("%s  memory = %q\n", toml, memory)

--- a/dagrr/fly.go
+++ b/dagrr/fly.go
@@ -26,6 +26,14 @@ func (m *DagrrFly) Manifest(
 	// +optional
 	// +default="performance-2x"
 	size string,
+
+	// Memory to request, see https://fly.io/docs/reference/configuration/#memory
+	// +optional
+	memory string,
+
+	// GPU kind to use, see https://fly.io/docs/reference/configuration/#gpu_kind
+	// +optional
+	gpuKind string,
 ) *dagger.Directory {
 	toml := fmt.Sprintf(`# https://fly.io/docs/reference/configuration/
 
@@ -67,7 +75,15 @@ kill_timeout = 30
 
 [[vm]]
   size = "%s"
-	`, m.Dagrr.App, m.Dagrr.Version, disk, size)
+`, m.Dagrr.App, m.Dagrr.Version, disk, size)
+
+	if memory != "" {
+		toml = fmt.Sprintf("%s  memory = %q\n", toml, memory)
+	}
+
+	if gpuKind != "" {
+		toml = fmt.Sprintf("%s  gpu_kind = %q\n", toml, gpuKind)
+	}
 
 	return dag.Directory().WithNewFile("fly.toml", toml)
 }
@@ -87,7 +103,7 @@ func (m *DagrrFly) Deploy(
 	}
 
 	if dir == nil {
-		dir = m.Manifest("100GB", "performance-2x")
+		dir = m.Manifest("100GB", "performance-2x", "", "")
 	}
 
 	return m.Flyio.Deploy(ctx, dir)

--- a/dagrr/main.go
+++ b/dagrr/main.go
@@ -79,3 +79,8 @@ func (m *Dagrr) OnFlyio(
 func (m *Dagrr) versionUrlized() string {
 	return "v" + strings.ReplaceAll(m.Version, ".", "-")
 }
+
+// Returns the app name
+func (m *Dagrr) GetApp() string {
+	return m.App
+}

--- a/dagrr/main.go
+++ b/dagrr/main.go
@@ -80,7 +80,7 @@ func (m *Dagrr) versionUrlized() string {
 	return "v" + strings.ReplaceAll(m.Version, ".", "-")
 }
 
-// Returns the app name
+// Returns the app name: `dagger call get-app`
 func (m *Dagrr) GetApp() string {
 	return m.App
 }

--- a/flyio/main.go
+++ b/flyio/main.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// https://hub.docker.com/r/flyio/flyctl/tags
-	latestVersion = "0.2.93"
+	latestVersion = "0.3.45"
 )
 
 type Flyio struct {
@@ -36,7 +36,7 @@ func New(
 	// +default="personal"
 	org string,
 
-	// flyctl version to use: `--version=0.2.79`
+	// flyctl version to use: `--version=0.2.29`
 	//
 	// +optional
 	version string,

--- a/flyio/main.go
+++ b/flyio/main.go
@@ -108,3 +108,15 @@ func (m *Flyio) Terminal(
 		WithExec([]string{"/flyctl", "ssh", "console", "--app", app, "--org", m.Org}).
 		Terminal()
 }
+
+// Destroys app: `dagger call ... destroy --app=gostatic-example-2024-07-03`
+func (m *Flyio) Destroy(
+	ctx context.Context,
+	// App name: `--app=myapp-2024-07-03`
+	app string,
+
+) (string, error) {
+	return m.Container.
+		WithExec([]string{"/flyctl", "apps", "destroy", "--yes", app}).
+		Stdout(ctx)
+}

--- a/flyio/main.go
+++ b/flyio/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"main/internal/dagger"
+	"strings"
 	"time"
 )
 
@@ -68,11 +69,19 @@ func (m *Flyio) Deploy(
 	ctx context.Context,
 	// App directory - must contain `fly.toml`
 	dir *dagger.Directory,
+	// Regions - only deploy to the following regions
+	// +optional
+	regions []string,
 ) (string, error) {
+	args := []string{"/flyctl", "deploy"}
+	if len(regions) > 0 {
+		args = append(args, "--regions")
+		args = append(args, strings.Join(regions, ","))
+	}
 	return m.Container.
 		WithMountedDirectory("/app", dir).
 		WithWorkdir("/app").
-		WithExec([]string{"/flyctl", "deploy"}).
+		WithExec(args).
 		Stdout(ctx)
 }
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,91 @@
+# vim: set tabstop=4 shiftwidth=4 expandtab:
+
+[private]
+default:
+    just --list
+
+[private]
+fmt:
+    just --fmt --check --unstable
+
+[private]
+dagger:
+    @dagger version > /dev/null \
+    || echo "{{ _REDB }}{{ _WHITE }} Please install dagger CLI {{ _RESET }} https://docs.dagger.io/install/"
+
+[private]
+flyctl:
+    @flyctl version > /dev/null \
+    || echo "{{ _REDB }}{{ _WHITE }} Please install flyctl CLI {{ _RESET }} https://fly.io/docs/flyctl/install/"
+    @flyctl auth whoami > /dev/null
+
+_DAGRR_APP_NAME := "testing-dagrr-" + datetime("%Y-%m-%d")
+
+# Run through daggr commands and make sure they work as expected
+dagrr: dagger flyctl
+    @echo "{{ _MAGENTA }}\n🗡️ Get auto-generated app name...{{ _RESET }}"
+    dagger call -m dagrr \
+        get-app
+
+    @echo "{{ _MAGENTA }}\n🗡️ Get custom app name...{{ _RESET }}"
+    dagger call -m dagrr --app={{ _DAGRR_APP_NAME }} \
+        get-app
+
+    @echo "{{ _MAGENTA }}\n🗡️ Generate Dagger Engine on Fly.io manifest...{{ _RESET }}"
+    FLY_API_TOKEN=$(flyctl auth token) dagger call -m dagrr --app={{ _DAGRR_APP_NAME }} \
+        on-flyio --token=env:FLY_API_TOKEN \
+            manifest \
+                file --path=fly.toml \
+                    export --path=fly.toml
+    cat fly.toml
+
+    @echo "{{ _MAGENTA }}\n🗡️ Deploy Dagger Engine on Fly.io with generated manifest...{{ _RESET }}"
+    FLY_API_TOKEN=$(flyctl auth token) dagger call -m dagrr --app={{ _DAGRR_APP_NAME }} \
+        on-flyio --token=env:FLY_API_TOKEN \
+            deploy --dir=.
+
+    @echo "{{ _MAGENTA }}\n🗡️ Delete Dagger Engine on Fly.io...{{ _RESET }}"
+    FLY_API_TOKEN=$(flyctl auth token) dagger call -m dagrr --app={{ _DAGRR_APP_NAME }} \
+        on-flyio --token=env:FLY_API_TOKEN \
+            destroy
+    rm fly.toml
+
+    @echo "{{ _MAGENTA }}\n🗡️ Generate Dagger Engine on Fly.io manifest with GPU support and all the other customizations...{{ _RESET }}"
+    FLY_API_TOKEN=$(flyctl auth token) dagger call -m dagrr --version=0.13.7 --app={{ _DAGRR_APP_NAME }}-gpu \
+        on-flyio --token=env:FLY_API_TOKEN \
+            manifest --primary-region=ord --size=performance-1x --memory=4GB --gpu-kind=a10 --disk=50GB --environment="FOO = 'foo'" --environment="BAR = 'bar'" \
+                file --path=fly.toml \
+                    export --path=fly.toml
+    cat fly.toml
+
+    @echo "{{ _MAGENTA }}\n🗡️ Deploy Dagger Engine on Fly.io with new manifest...{{ _RESET }}"
+    FLY_API_TOKEN=$(flyctl auth token) dagger call -m dagrr --app={{ _DAGRR_APP_NAME }}-gpu \
+        on-flyio --token=env:FLY_API_TOKEN --org=dagger \
+            deploy --dir=.
+
+    @echo "{{ _MAGENTA }}\n🗡️ Delete Dagger Engine on Fly.io...{{ _RESET }}"
+    FLY_API_TOKEN=$(flyctl auth token) dagger call -m dagrr --app={{ _DAGRR_APP_NAME }}-gpu \
+        on-flyio --token=env:FLY_API_TOKEN --org=dagger \
+            destroy
+    rm fly.toml
+
+# https://linux.101hacks.com/ps1-examples/prompt-color-using-tput/
+
+_BOLD := "$(tput bold)"
+_RESET := "$(tput sgr0)"
+_BLACK := "$(tput bold)$(tput setaf 0)"
+_RED := "$(tput bold)$(tput setaf 1)"
+_GREEN := "$(tput bold)$(tput setaf 2)"
+_YELLOW := "$(tput bold)$(tput setaf 3)"
+_BLUE := "$(tput bold)$(tput setaf 4)"
+_MAGENTA := "$(tput bold)$(tput setaf 5)"
+_CYAN := "$(tput bold)$(tput setaf 6)"
+_WHITE := "$(tput bold)$(tput setaf 7)"
+_BLACKB := "$(tput bold)$(tput setab 0)"
+_REDB := "$(tput setab 1)$(tput setaf 0)"
+_GREENB := "$(tput setab 2)$(tput setaf 0)"
+_YELLOWB := "$(tput setab 3)$(tput setaf 0)"
+_BLUEB := "$(tput setab 4)$(tput setaf 0)"
+_MAGENTAB := "$(tput setab 5)$(tput setaf 0)"
+_CYANB := "$(tput setab 6)$(tput setaf 0)"
+_WHITEB := "$(tput setab 7)$(tput setaf 0)"


### PR DESCRIPTION
Several changes to be able to deploy a gpu-enabled Dagger engine on Fly.io

Example: https://github.com/samalba/dagger-modules/blob/1fd96d5d12921628baa4823d0790a299b7d523ca/nvidia-gpu/main.go#L27